### PR TITLE
fix(lua): satisfy BN EmmyLua checks

### DIFF
--- a/heart.lua
+++ b/heart.lua
@@ -524,12 +524,13 @@ local function set_terrain_at_local_pos(coord, terrain_id)
   -- Create the tripoint at the specified local coordinates
   local player = gapi.get_avatar()
   local player_bub_ms_pos = player:get_pos_ms()
-  local player_bub_omt_pos = map:bub_to_abs(player_bub_ms_pos):to_omt():xy()
-  local pos = player_bub_omt_pos:project_combine(coord)
+  local player_abs_omt_pos = map:bub_to_abs(player_bub_ms_pos):to_omt()
+  local target_abs_omt_pos = TripointAbsOmt.new(player_abs_omt_pos.x, player_abs_omt_pos.y, coord.z)
+  local pos = target_abs_omt_pos:project_combine(coord:xy())
 
   -- Set the terrain
   local current_ter = map:get_ter_at(map:abs_to_bub(pos))
-  gapi.add_msg(locale.gettext("current ter at %s is %s"), map:abs_to_bub(pos), current_ter)
+  gapi.add_msg(string.format(locale.gettext("current ter at %s is %s"), map:abs_to_bub(pos), current_ter))
   local success = map:set_ter_at(map:abs_to_bub(pos), ter_int)
   if not success then
     gapi.add_msg(locale.gettext("WARNING: Failed to set terrain at position"))

--- a/preload.lua
+++ b/preload.lua
@@ -164,23 +164,19 @@ game.iuse_functions["SKYISLAND_IMPRINT_CVD_PANEL"] = {
 }
 
 -- Register hooks
-table.insert(game.hooks.on_game_started, function(...)
+game.add_hook("on_game_started", function(...)
   return mod.on_game_started(...)
 end)
 
-table.insert(game.hooks.on_game_load, function(...)
+game.add_hook("on_game_load", function(...)
   return mod.on_game_load(...)
 end)
 
-table.insert(game.hooks.on_game_save, function(...)
+game.add_hook("on_game_save", function(...)
   return mod.on_game_save(...)
 end)
 
--- table.insert(game.hooks.on_char_death, function(...)
---   return mod.on_char_death(...)
--- end)
-
-table.insert(game.hooks.on_character_death, function(...)
+game.add_hook("on_character_death", function(...)
   return mod.on_character_death(...)
 end)
 


### PR DESCRIPTION
## Summary
- Register hooks through `game.add_hook` so BN's hook annotations match runtime use.
- Compose construction coordinates with concrete absolute OMT/OMT-local types.
- Format terrain debug messages before passing them to `gapi.add_msg`.

## Testing
- Copied this worktree into Cataclysm-BN as `data/mods/cbn_sky_island`; `emmylua_check .` completed with warnings only.
- `cataclysm-bn-tiles --dont-debugmsg --check-mods CBN_Sky_Island` loaded the mod.

Related: https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27803551989

<sub>PR opened by gpt-5.5 high on pi</sub>
